### PR TITLE
improved regex and added data attribute to skip lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Placeholders for images can be styled, i.e. like this:
     background-size: 16px 16px;
 }`
 
+### Excluding images ###
+
+It's possible to exclude some images from the lazy loading. This can be achieved by adding an attribute `data-crazy-lazy="exclude"` to the images that should not lazy loaded by the plugin. 
 
 ### Video ###
 [youtube http://www.youtube.com/watch?v=tMv5tl3Q4Aw]

--- a/inc/crazy-lazy.class.php
+++ b/inc/crazy-lazy.class.php
@@ -80,9 +80,6 @@ final class CrazyLazy {
 			return $content;
 		}
 
-		/* Empty gif */
-		$null = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-
 		/* Replace images */
 		return preg_replace_callback(
 			'/(?P<all>                                                              (?# match the whole img tag )
@@ -99,23 +96,34 @@ final class CrazyLazy {
 				(?P<after>[^>]*)                                                    (?# match any additional optional attributes )
 				(?P<closing>\/?)>                                                   (?# match the closing of the img tag with or without a self closing slash )
 			)/x',
-			function( $matches ) use ( $null ) {
-				// Return unmodified image if the "data skip" attribute was found.
-				if ( false !== strpos( $matches['all'], 'data-crazy-lazy="exclude"' ) ) {
-					return $matches['all'];
-				} else {
-					return '<img ' . $matches['before']
-					       . ' class="crazy_lazy ' . $matches['class1'] . $matches['class2']
-					       . ' "src="' . $null . '"'
-					       . $matches['between1'] . $matches['between2']
-					       . ' data-src="' . $matches['src1'] . $matches['src2'] . '"'
-					       . $matches['after']
-					       . ' style="display:none"'
-					       . $matches['closing'] . '><noscript>' . $matches['all'] . '</noscript>';
-				}
-			},
+			array( 'CrazyLazy', 'replace_images' ),
 			$content
 		);
+	}
+
+	/**
+	 * The callback function for the preg_match_callback to modify the img tags.
+	 *
+	 * @param array $matches The regex matches.
+	 *
+	 * @return string The modified content string.
+	 */
+	public static function replace_images( $matches ) {
+		/* Empty gif */
+		$null = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+		// Return unmodified image if the "data skip" attribute was found.
+		if ( false !== strpos( $matches['all'], 'data-crazy-lazy="exclude"' ) ) {
+			return $matches['all'];
+		} else {
+			return '<img ' . $matches['before']
+			       . ' class="crazy_lazy ' . $matches['class1'] . $matches['class2']
+			       . ' "src="' . $null . '"'
+			       . $matches['between1'] . $matches['between2']
+			       . ' data-src="' . $matches['src1'] . $matches['src2'] . '"'
+			       . $matches['after']
+			       . ' style="display:none"'
+			       . $matches['closing'] . '><noscript>' . $matches['all'] . '</noscript>';
+		}
 	}
 
 

--- a/inc/crazy-lazy.class.php
+++ b/inc/crazy-lazy.class.php
@@ -101,7 +101,7 @@ final class CrazyLazy {
 			)/x',
 			function( $matches ) use ( $null ) {
 				// Return unmodified image if the "data skip" attribute was found.
-				if ( false !== strpos( $matches['all'], 'data-crazy-lazy="skip"' ) ) {
+				if ( false !== strpos( $matches['all'], 'data-crazy-lazy="exclude"' ) ) {
 					return $matches['all'];
 				} else {
 					return '<img ' . $matches['before']

--- a/inc/crazy-lazy.class.php
+++ b/inc/crazy-lazy.class.php
@@ -84,16 +84,36 @@ final class CrazyLazy {
 		$null = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
 
 		/* Replace images */
-
-		return preg_replace(
-			array(
-				'#(<img(.+?)class=["\'](.*?(?:wp-image-|wp-post-image).+?)["\'](.+?)src=["\'](.+?)["\'](.*?)(/?)>)#',
-				'#(<img(.+?)src=["\'](.+?)["\'](.+?)class=["\'](.*?(?:wp-image-|wp-post-image).+?)["\'](.*?)(/?)>)#',
-			),
-			array(
-				'<img ${2} class="crazy_lazy ${3}" src="' . $null . '" ${4} data-src="${5}" ${6} style="display:none" ${7}><noscript>${1}</noscript>',
-				'<img ${2} src="' . $null . '" data-src="${3}" ${4} class="crazy_lazy ${5}" ${6} style="display:none" ${7}><noscript>${1}</noscript>',
-			),
+		return preg_replace_callback(
+			'/(?P<all>                                                              (?# match the whole img tag )
+				<img(?P<before>[^>]*)                                               (?# the opening of the img and some optional attributes )
+				(                                                                   (?# match a class attribute followed by some optional ones and the src attribute )
+					class=["\'](?P<class1>.*?(?:wp-image-|wp-post-image).+?)["\']
+					(?P<between1>[^>]*)
+					src=["\'](?P<src1>[^>"\']*)["\']
+					|                                                               (?# match same as before, but with the src attribute before the class attribute )
+					src=["\'](?P<src2>[^>"\']*)["\']
+					(?P<between2>[^>]*)
+					class=["\'](?P<class2>.*?(?:wp-image-|wp-post-image).+?)["\']
+				)
+				(?P<after>[^>]*)                                                    (?# match any additional optional attributes )
+				(?P<closing>\/?)>                                                   (?# match the closing of the img tag with or without a self closing slash )
+			)/x',
+			function( $matches ) use ( $null ) {
+				// Return unmodified image if the "data skip" attribute was found.
+				if ( false !== strpos( $matches['all'], 'data-crazy-lazy="skip"' ) ) {
+					return $matches['all'];
+				} else {
+					return '<img ' . $matches['before']
+					       . ' class="crazy_lazy ' . $matches['class1'] . $matches['class2']
+					       . ' "src="' . $null . '"'
+					       . $matches['between1'] . $matches['between2']
+					       . ' data-src="' . $matches['src1'] . $matches['src2'] . '"'
+					       . $matches['after']
+					       . ' style="display:none"'
+					       . $matches['closing'] . '><noscript>' . $matches['all'] . '</noscript>';
+				}
+			},
 			$content
 		);
 	}


### PR DESCRIPTION
-  only one regex and replacement in a callback funtion
- commenting regex for easier debugging on further bugs or feature requests
- check in the callback function the attribute "data-crazy-lazy" for "skip"
  
  Closes #9 and #11.
