### PR TITLE
Add support for text and html widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: php
+
+sudo: required
+addons:
+  chrome: stable
+
+stages:
+  - quality
+
+jobs:
+  include:
+    - stage: quality
+      php: '7.0'
+      script: ./vendor/bin/phpcs ./ --standard=./phpcs.config.xml -s
+
+cache:
+  directories:
+  - vendor
+  - $HOME/.composer/cache
+
+before_install:
+  - phpenv config-rm xdebug.ini || true
+  - composer self-update
+
+install:
+  - composer install
+
+# We should also add codecov.
+#after_success:
+#- bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,34 @@
+{
+	"name": "pluginkollektiv/crazy-lazy",
+	"description": "Lazy load images. Simple to use: Activate, done. Search engine and noscript user friendly.",
+	"keywords": [
+		"WordPress",
+		"lazy loading"
+	],
+	"homepage": "https://pluginkollektiv.github.io/crazy-lazy/",
+	"authors": [
+		{
+			"name": "pluginkollektiv",
+			"homepage": "https://github.com/pluginkollektiv",
+			"role": "Maintainer"
+		}
+	],
+	"support": {
+		"issues": "https://github.com/pluginkollektiv/crazy-lazy/issues",
+		"source": "https://github.com/pluginkollektiv/crazy-lazy",
+		"docs": "https://github.com/pluginkollektiv/crazy-lazy/blob/master/README.md"
+	},
+	"type": "wordpress-plugin",
+	"license": "GPL-v2",
+	"require-dev": {
+		"phpunit/phpunit": "^4",
+		"brain/monkey": "^1.4",
+		"wp-cli/wp-cli": "~1.3",
+		"paulgibbs/behat-wordpress-extension": "^1.0",
+		"behat/mink-extension": "v2.2",
+		"behat/mink-goutte-driver": "^1.2",
+		"behat/mink-selenium2-driver": "^1.3",
+		"wp-coding-standards/wpcs": "^0.14.1",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,6 @@
 	"type": "wordpress-plugin",
 	"license": "GPL-v2",
 	"require-dev": {
-		"phpunit/phpunit": "^4",
-		"brain/monkey": "^1.4",
-		"wp-cli/wp-cli": "~1.3",
-		"paulgibbs/behat-wordpress-extension": "^1.0",
-		"behat/mink-extension": "v2.2",
-		"behat/mink-goutte-driver": "^1.2",
-		"behat/mink-selenium2-driver": "^1.3",
 		"wp-coding-standards/wpcs": "^0.14.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
 	}

--- a/crazy-lazy.php
+++ b/crazy-lazy.php
@@ -41,7 +41,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 defined( 'ABSPATH' ) || exit;
 
 
-/* FE only */
+/* Frontend only */
 if ( is_admin() ) {
 	return;
 }
@@ -50,6 +50,6 @@ if ( is_admin() ) {
 /* Fire! */
 define( 'CRAZY_LAZY_BASE', plugin_basename( __FILE__ ) );
 
-require_once( dirname( __FILE__ ) . '/inc/crazy-lazy.class.php' );
+require_once dirname( __FILE__ ) . '/inc/class-crazylazy.php';
 
 add_action( 'wp', array( 'CrazyLazy', 'instance' ) );

--- a/inc/class-crazylazy.php
+++ b/inc/class-crazylazy.php
@@ -39,6 +39,13 @@ final class CrazyLazy {
 		}
 
 		/* Hooks */
+		add_action(
+			'init',
+			array(
+				__CLASS__,
+				'load_plugin_textdomain'
+			)
+		);
 		add_filter(
 			'the_content',
 			array(
@@ -77,6 +84,12 @@ final class CrazyLazy {
 		);
 	}
 
+	/**
+	 * Load the textdomain for backward compatibility of older WordPress versions and to prevent a warning in GlotPress.
+	 */
+	public function load_plugin_textdomain() {
+		load_plugin_textdomain( 'crazy-lazy' );
+	}
 
 	/**
 	 * Prepare content images for Crazy Lazy usage

--- a/inc/class-crazylazy.php
+++ b/inc/class-crazylazy.php
@@ -6,7 +6,7 @@
  */
 
 /* Quit */
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 
 /**
@@ -131,13 +131,13 @@ final class CrazyLazy {
 		if ( false !== strpos( $matches['all'], 'data-crazy-lazy="exclude"' ) || false !== strpos( $matches['class1'] . $matches['class2'], 'crazy_lazy' ) ) {
 			return $matches['all'];
 		} else {
-            return '<img ' . $matches['before']
-                   . ' style="display:none" '
-                   . ' class="crazy_lazy ' . $matches['class1'] . $matches['class2'] . '" src="' . $null . '" '
-                   . $matches['between1'] . $matches['between2']
-                   . ' data-src="' . $matches['src1'] . $matches['src2'] . '" '
-                   . $matches['after']
-                   . $matches['closing'] . '><noscript>' . $matches['all'] . '</noscript>';
+			return '<img ' . $matches['before']
+				. ' style="display:none" '
+				. ' class="crazy_lazy ' . $matches['class1'] . $matches['class2'] . '" src="' . $null . '" '
+				. $matches['between1'] . $matches['between2']
+				. ' data-src="' . $matches['src1'] . $matches['src2'] . '" '
+				. $matches['after']
+				. $matches['closing'] . '><noscript>' . $matches['all'] . '</noscript>';
 		}
 	}
 
@@ -154,9 +154,9 @@ final class CrazyLazy {
 
 		/* Check for jQuery */
 		if ( ! empty( $wp_scripts ) && (bool) $wp_scripts->query( 'jquery' ) ) { /* hot fix for buggy wp_script_is() */
-			self::_print_jquery_lazyload();
+			self::print_jquery_lazyload();
 		} else {
-			self::_print_javascript_lazyload();
+			self::print_javascript_lazyload();
 		}
 	}
 
@@ -167,7 +167,7 @@ final class CrazyLazy {
 	 * @since   0.0.5
 	 * @change  0.0.9
 	 */
-	private static function _print_jquery_lazyload() {
+	private static function print_jquery_lazyload() {
 		wp_enqueue_script(
 			'unveil.js',
 			plugins_url(
@@ -175,7 +175,7 @@ final class CrazyLazy {
 				CRAZY_LAZY_BASE
 			),
 			array( 'jquery' ),
-			'',
+			'1.0.4',
 			true
 		);
 	}
@@ -186,7 +186,7 @@ final class CrazyLazy {
 	 * @since   0.0.5
 	 * @change  0.0.9
 	 */
-	private static function _print_javascript_lazyload() {
+	private static function print_javascript_lazyload() {
 		wp_enqueue_script(
 			'lazyload.js',
 			plugins_url(
@@ -194,7 +194,7 @@ final class CrazyLazy {
 				CRAZY_LAZY_BASE
 			),
 			array(),
-			'',
+			'1.0.4',
 			true
 		);
 	}

--- a/inc/crazy-lazy.class.php
+++ b/inc/crazy-lazy.class.php
@@ -54,6 +54,20 @@ final class CrazyLazy {
 				'prepare_images',
 			)
 		);
+		add_filter(
+			'widget_text',
+			array(
+				__CLASS__,
+				'prepare_images',
+			)
+		);
+		add_filter(
+			'get_avatar',
+			array(
+				__CLASS__,
+				'prepare_images',
+			)
+		);
 		add_action(
 			'wp_enqueue_scripts',
 			array(
@@ -76,7 +90,7 @@ final class CrazyLazy {
 	 */
 	public static function prepare_images( $content ) {
 		/* No lazy images? */
-		if ( strpos( $content, '-image' ) === false ) {
+		if ( strpos( $content, '-image' ) === false && strpos( $content, 'avatar-' ) === false ) {
 			return $content;
 		}
 
@@ -85,13 +99,13 @@ final class CrazyLazy {
 			'/(?P<all>                                                              (?# match the whole img tag )
 				<img(?P<before>[^>]*)                                               (?# the opening of the img and some optional attributes )
 				(                                                                   (?# match a class attribute followed by some optional ones and the src attribute )
-					class=["\'](?P<class1>.*?(?:wp-image-|wp-post-image)[^>"\']*)["\']
+					class=["\'](?P<class1>.*?(?:wp-image-|wp-post-image|avatar-)[^>"\']*)["\']
 					(?P<between1>[^>]*)
 					src=["\'](?P<src1>[^>"\']*)["\']
 					|                                                               (?# match same as before, but with the src attribute before the class attribute )
 					src=["\'](?P<src2>[^>"\']*)["\']
 					(?P<between2>[^>]*)
-					class=["\'](?P<class2>.*?(?:wp-image-|wp-post-image)[^>"\']*)["\']
+					class=["\'](?P<class2>.*?(?:wp-image-|wp-post-image|avatar-)[^>"\']*)["\']
 				)
 				(?P<after>[^>]*)                                                    (?# match any additional optional attributes )
 				(?P<closing>\/?)>                                                   (?# match the closing of the img tag with or without a self closing slash )

--- a/phpcs.config.xml
+++ b/phpcs.config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset name="Coding Standards">
+    <rule ref="WordPress">
+        <exclude name="WordPress.VIP.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__" />
+        <exclude name="WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents" />
+        <exclude name="WordPress.VIP.FileSystemWritesDisallow.file_ops_file_put_contents" />
+        <exclude name="WordPress.VIP.FileSystemWritesDisallow.file_ops_is_writable" />
+        <exclude name="WordPress.VIP.DirectDatabaseQuery.NoCaching" />
+        <exclude name="WordPress.VIP.DirectDatabaseQuery.DirectQuery" />
+        <exclude name="WordPress.VIP.SuperGlobalInputUsage.AccessDetected" />
+        <exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+        <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.url_to_postid_url_to_postid" />
+
+
+        <!-- tmp exclude -->
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
+    </rule>
+    <file>.</file>
+    <exclude-pattern>/vendor/*</exclude-pattern>
+    <exclude-pattern>/node_modules/*</exclude-pattern>
+    <exclude-pattern>/tests/*</exclude-pattern>
+    <exclude-pattern>*.js</exclude-pattern>
+    <exclude-pattern>*.css</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
Does not work for galleries in html widgets, because there is no filter in the `widget()` method after the gallery shortcode is parsed.

It’s not possible to add lazy loading for media widgets (image and gallery) at the moment, because there is no filter for the `wp_get_attachment_image()` output (https://core.trac.wordpress.org/ticket/27399).

Fixes #20.