### PR TITLE
Add EOL notice, release version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ Contributors:      pluginkollektiv
 Tags:              lazy, load, loading, performance, images  
 Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW  
 Requires at least: 3.6  
-Tested up to:      5.4  
-Stable tag:        1.1.0  
+Tested up to:      5.6  
+Stable tag:        1.2.0  
 License:           GPLv2 or later  
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html  
 Lazy load images. Simple to use: activate, done. Search engine and noscript user friendly.  
 
 ## Description ##
+**Warning: *Crazy Lazy* has reached end of life. WordPress 5.5+ supports [lazy-loading of images in Core](https://make.wordpress.org/core/2020/07/14/lazy-loading-images-in-5-5/) based on the native HTML `loading` attribute. If you look for an alternative plugin, we recommend to use [Lazy Loader](https://wordpress.org/plugins/lazy-loading-responsive-images/) instead.**
+
 *Crazy Lazy* helps increasing the performance of your blog or website by displaying images efficiently. When a page would usually display some images, *Crazy Lazy* will prevent those images to load. Only when a user scrolls down the page and reaches the position where an image actually should be displayed, that particular image will be loaded from the server.
 
 By loading images only when needed, *Crazy Lazy* will reducing page loading times and (potentially costly) traffic.
 
 This Lazy Load plugin is structured very lean and does not require any settings: activate, done. Depending on the theme or the usage of jQuery *Crazy Lazy* optionally will utilze a modified version of the jQuery plugin [Unveil.js](https://github.com/luis-almeida/unveil), or the native JavaScript library [lazyload.js](https://gist.github.com/miloplacencia/3931803).
-
-[](http://coderisk.com/wp/plugin/crazy-lazy/RIPS-pR7PC89HbM)
 
 ### Styling ###
 Placeholders for images can be styled, i.e. like this:
@@ -67,8 +67,13 @@ Crazy Lazy will work with every caching plugin, including our own [Cachify](http
 
 
 ## Changelog ##
+
+### 1.2.0 ###
+* Fix PHP warning due to undefined index (#37, #38) - thanks to Rouven Hurling
+* Add EOL notice to the admin area recommending Lazy Loader as an alternative
+
 ### 1.1.0 ###
- *add support for image block using a skip-class
+* add support for image block using a skip-class
 
 ### 1.0.5 ###
 * add support for new skip data attribute "data-skip-lazy" and CSS class "skip-lazy"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
 	"license": "GPL-v2",
 	"require-dev": {
 		"wp-coding-standards/wpcs": "^0.14.1",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1"
 	}
 }

--- a/crazy-lazy.php
+++ b/crazy-lazy.php
@@ -15,7 +15,7 @@
  * Text Domain: crazy-lazy
  * License:     GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     1.1.0
+ * Version:     1.2.0
  */
 
 /*

--- a/crazy-lazy.php
+++ b/crazy-lazy.php
@@ -40,16 +40,22 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /* Quit */
 defined( 'ABSPATH' ) || exit;
 
-
-/* Frontend only */
-if ( is_admin() ) {
-	return;
-}
-
-
 /* Fire! */
 define( 'CRAZY_LAZY_BASE', plugin_basename( __FILE__ ) );
 
 require_once dirname( __FILE__ ) . '/inc/class-crazylazy.php';
+
+if ( is_admin() ) {
+	add_action(
+		is_network_admin() ? 'network_admin_notices' : 'admin_notices',
+		array(
+			'CrazyLazy',
+			'add_deprecation_notice',
+		)
+	);
+
+	/* Frontend only */
+	return;
+}
 
 add_action( 'wp', array( 'CrazyLazy', 'instance' ) );

--- a/inc/class-crazylazy.php
+++ b/inc/class-crazylazy.php
@@ -111,6 +111,7 @@ final class CrazyLazy {
 					if ( version_compare( $wp_version, '5.5', '>=' ) ) {
 						echo esc_html(
 							sprintf(
+								/* translators: WordPress version */
 								__( 'As you are running WordPress %s, images are lazy loaded by default.', 'crazy-lazy' ),
 								$wp_version
 							)
@@ -118,6 +119,7 @@ final class CrazyLazy {
 					} else {
 						echo esc_html(
 							sprintf(
+								/* translators: WordPress version */
 								__( 'You are running WordPress %s, the feature is not available.', 'crazy-lazy' ),
 								$wp_version
 							)

--- a/inc/class-crazylazy.php
+++ b/inc/class-crazylazy.php
@@ -85,6 +85,71 @@ final class CrazyLazy {
 	}
 
 	/**
+	 * Add deprecation notice in WP Admin.
+	 */
+	public static function add_deprecation_notice() {
+		// Only show notice for users who can actually uninstall or update plugins.
+		if ( ! current_user_can( 'delete_plugins' ) && ! current_user_can( 'update_plugins' ) ) {
+			return;
+		}
+
+		global $wp_version;
+		?>
+<div class="notice notice-warning">
+			<p>
+				<?php
+				echo wp_kses(
+					__( 'Crazy Lazy is deprecated in favor of <a href="https://make.wordpress.org/core/2020/07/14/lazy-loading-images-in-5-5/">lazy loading in Core</a> and the <a href="https://wordpress.org/plugins/lazy-loading-responsive-images/">Lazy Loader</a> plugin.', 'crazy-lazy' ),
+					array( 'a' => array( 'href' => array() ) )
+				);
+				?>
+			</p>
+			<ol>
+				<li>
+					<?php esc_html_e( 'Lazy loading in Core (available in WordPress 5.5+) is based on the native HTML loading attribute.', 'crazy-lazy' ); ?>
+					<?php
+					if ( version_compare( $wp_version, '5.5', '>=' ) ) {
+						echo esc_html(
+							sprintf(
+								__( 'As you are running WordPress %s, images are lazy loaded by default.', 'crazy-lazy' ),
+								$wp_version
+							)
+						);
+					} else {
+						echo esc_html(
+							sprintf(
+								__( 'You are running WordPress %s, the feature is not available.', 'crazy-lazy' ),
+								$wp_version
+							)
+						);
+					}
+					?>
+				</li>
+				<?php if ( is_plugin_active( 'lazy-loading-responsive-images/lazy-load-responsive-images.php' ) ) { ?>
+					<li><?php esc_html_e( 'As Lazy Loader is active, you can deactivate and uninstall Crazy Lazy.', 'crazy-lazy' ); ?></li>
+					<?php
+				} else {
+					$install_url = add_query_arg(
+						array(
+							's'    => 'florianbrinkmann',
+							'tab'  => 'search',
+							'type' => 'author',
+						),
+						admin_url( '/plugin-install.php' )
+					);
+					?>
+					<li><?php esc_html_e( 'In case you still need a lazy loading plugin, we recommend to switch to Lazy Loader:', 'crazy-lazy' ); ?>
+						<a href="<?php echo esc_attr( $install_url ); ?>">
+							<?php esc_html_e( 'Install now.', 'crazy-lazy' ); ?>
+						</a>
+					</li>
+				<?php } ?>
+			</ol>
+		</div>
+		<?php
+	}
+
+	/**
 	 * Load the textdomain for backward compatibility of older WordPress versions and to prevent a warning in GlotPress.
 	 */
 	public function load_plugin_textdomain() {
@@ -158,7 +223,7 @@ final class CrazyLazy {
 			if ( ! isset( $matches['figure_closing'] ) ) {
 				$matches['figure_closing'] = '';
 			}
-			
+
 			return $matches['figure_opening'] . '<img ' . $matches['before']
 				. ' style="display:none" '
 				. ' class="crazy_lazy ' . $matches['class1'] . $matches['class2'] . '" src="' . $null . '" '

--- a/inc/class-crazylazy.php
+++ b/inc/class-crazylazy.php
@@ -106,14 +106,23 @@ final class CrazyLazy {
 			</p>
 			<ol>
 				<li>
-					<?php esc_html_e( 'Lazy loading in Core (available in WordPress 5.5+) is based on the native HTML loading attribute.', 'crazy-lazy' ); ?>
+					<?php
+					echo wp_kses(
+						__( 'Lazy loading in Core (available in WordPress 5.5+) is based on the HTML <code>loading</code> attribute.', 'crazy-lazy' ),
+						array( 'code' => array() )
+					);
+					?>
 					<?php
 					if ( version_compare( $wp_version, '5.5', '>=' ) ) {
-						echo esc_html(
+						echo wp_kses(
 							sprintf(
 								/* translators: WordPress version */
-								__( 'As you are running WordPress %s, images are lazy loaded by default.', 'crazy-lazy' ),
+								__( 'As you are running WordPress %s, images are lazy loaded by default in <a href="https://caniuse.com/loading-lazy-attr">browsers supporting native lazy loading</a>.', 'crazy-lazy' ),
 								$wp_version
+							),
+							array(
+								'a'    => array( 'href' => array() ),
+								'code' => array(),
 							)
 						);
 					} else {


### PR DESCRIPTION
As discussed via Slack, we want to deprecate Crazy Lazy. Main reasons: WordPress supports native lazy loading (see #33) since WordPress 5.5. In addition, Lazy Loader by Florian Brinkmann is a good alternative which is maintained and has a larger user base (according to the statistics on WordPress.org).

To inform the users, this PR implements a final release showing an admin notice to users allowed to delete/update plugins.

This PR targets as the develop branch such that the README shown on GitHub is updated as well. After the PR is merged, the code should be merged into stable.